### PR TITLE
Make HttpEventStream non-copyable

### DIFF
--- a/src/httpeventstream.cpp
+++ b/src/httpeventstream.cpp
@@ -94,16 +94,6 @@ HttpEventStream::HttpEventStream(porla::ISession &session)
     m_torrentResumedConnection = m_session.OnTorrentResumed([this](auto s) { OnTorrentResumed(s); });
 }
 
-HttpEventStream::HttpEventStream(const HttpEventStream& hes)
-    : m_session(hes.m_session)
-{
-    m_sessionStatsConnection = m_session.OnSessionStats([this](auto s) { OnSessionStats(s); });
-    m_stateUpdateConnection = m_session.OnStateUpdate([this](auto s) { OnStateUpdate(s); });
-    m_torrentPausedConnection = m_session.OnTorrentPaused([this](auto s) { OnTorrentPaused(s); });
-    m_torrentRemovedConnection = m_session.OnTorrentRemoved([this](auto s) { OnTorrentRemoved(s); });
-    m_torrentResumedConnection = m_session.OnTorrentResumed([this](auto s) { OnTorrentResumed(s); });
-}
-
 HttpEventStream::~HttpEventStream()
 {
     m_sessionStatsConnection.disconnect();

--- a/src/httpeventstream.hpp
+++ b/src/httpeventstream.hpp
@@ -16,7 +16,7 @@ namespace porla
     {
     public:
         explicit HttpEventStream(ISession& session);
-        HttpEventStream(const HttpEventStream&);
+        HttpEventStream(const HttpEventStream&) = delete;
 
         ~HttpEventStream();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,8 +171,10 @@ int main(int argc, char* argv[])
             .port = cfg.http_port.value_or(1337)
         });
 
+        porla::HttpEventStream eventStream(session);
+
         http.Use(porla::HttpPost("/api/v1/jsonrpc", [&rpc](auto const& ctx) { rpc(ctx); }));
-        http.Use(porla::HttpGet("/api/v1/events", porla::HttpEventStream(session)));
+        http.Use(porla::HttpGet("/api/v1/events", [&eventStream](auto const& ctx) { eventStream(ctx); }));
         http.Use(porla::HttpNotFound());
 
         // If we run in supervised mode - print connection information here and finish


### PR DESCRIPTION
This fixes an issue when a client disconnects and `m_ctxs` becomes an invalid value for some reason.